### PR TITLE
Table of contents links break after an edit

### DIFF
--- a/tpl_functions.php
+++ b/tpl_functions.php
@@ -88,7 +88,7 @@ function _tpl_toc_to_twitter_bootstrap_event_hander_dump_level($data, $firstleve
 			$out .= '<li>' . html_list_toc($heading);
 			$li_open = true;
 		
-		}else if($$heading['level'] < $level) {
+		}else if($heading['level'] < $level) {
 			
 			// Close previous open li.
 			if($li_open) {


### PR DESCRIPTION
When I edit any of my wiki pages under this template, upon saving and reloading, the table of contents links don't work - they just link to an empty placeholder.

However after a couple of reloads, they start working - as if the indexing isn't being fired on save, maybe?

This doesn't happen on the default template, so I think its something in this template that can be fixed.

I'll have a look into this myself and post more info if I find it, just wondering if anyone else has had this and has any clues.
