### PR TITLE
fix 'Boostrap' typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Do something like the following:
 
 # Customization
 
-From the Configuration Manager screen you can change to any of the available boostrap themes on http://bootswatch.com/
+From the Configuration Manager screen you can change to any of the available bootstrap themes on http://bootswatch.com/
 
 If however you want to substitute the library with your own bootsrap theme you need to be aware of the following files
 

--- a/main.php
+++ b/main.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * DokuWiki Twitter Boostrap Template
+ * DokuWiki Twitter Bootstrap Template
  *
  * @link     https://github.com/ryanwmoore/dokutwitterbootstrap
  * @author   Ryan Moore <rwmoore07@gmail.com>

--- a/template.info.txt
+++ b/template.info.txt
@@ -2,6 +2,6 @@ base     dokubootstrapsimplified
 author   Paul in 't Hout
 email    badeendjuh@email.com
 date     2014-07-07
-name     Boostrap Simplified Template
+name     Bootstrap Simplified Template
 desc     DokuWiki template for Simplified content sharing.
 url      https://github.com/badeendjuh/dokubootstrap-simplified


### PR DESCRIPTION
Your GitHub repo description field also has the same typo.
