### PR TITLE
fix error in level for bs-nav menu

### DIFF
--- a/tpl_functions.php
+++ b/tpl_functions.php
@@ -96,8 +96,13 @@ function _tpl_toc_to_twitter_bootstrap_event_hander_dump_level($data, $firstleve
 			
 			// Close previous open li.
 			if($li_open) {
-				 $out .= '</li>';
-				 $li_open = false;
+				for ($i=0; $i < $level - $heading['level'] - 1; ++$i) {
+					$out .= '</li>';
+					$out .= '</ul>';
+				}
+				$out .= '</li>';
+				$li_open = false;
+				
 			}else{
 				 $out .= '';
 			}
@@ -108,7 +113,7 @@ function _tpl_toc_to_twitter_bootstrap_event_hander_dump_level($data, $firstleve
 		
 		$level = $heading['level'];
     }
-	
+
 	// Close previous open li.
     if($li_open) {
     	$out .= '</li>';


### PR DESCRIPTION
if difference of level between two sections is greated than one the nav menu display wrong level for the last elements.
This patch test the difference elvel between two sections and if this difference is more than one.
All previous level are correctly closed.
